### PR TITLE
Security: fixed world-writable Rprofile.site

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,6 +38,6 @@ r_install_dir = if node['kernel']['machine'] == 'x86_64'
 # Setting the default CRAN mirror makes
 # remote administration of R much easier.
 template "#{r_install_dir}/etc/Rprofile.site" do
-  mode "777"
+  mode "0555"
   variables( :cran_mirror => node['R']['cran_mirror'])
 end


### PR DESCRIPTION
Rprofile.site, as installed, is mode 777.  Probably not a desirable outcome, as that would allow any user on the system to execute arbitrary code as any other R user (including the R_package LWRP that runs as root.)
