### PR TITLE
Fixed potential bugs occurring under certain conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Berksfile.lock
 .*.sw[a-z]
 *.un~
 /cookbooks
+.idea
 
 # Bundler
 Gemfile.lock

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,5 +1,5 @@
 
-def package_installed?(package)
+def r_package_installed?(package)
   require "rinruby"
   R.echo(enable=false)
   R.eval "packages = installed.packages()[,1]"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ version          "0.3.0"
 depends "apt"
 depends "ark"
 depends "build-essential"
+depends 'readline'          # in case of future problems: was working with v0.0.3
 
 supports "ubuntu"
 supports "centos"

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -54,7 +54,8 @@ def load_current_resource
   @current_resource = Chef::Resource::RPackage.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
   @current_resource.package(@new_resource.package)
-  if package_installed?(@current_resource.package)
+  
+  if r_package_installed?(@current_resource.package)
     @current_resource.exists = true
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,6 +27,15 @@ end
 
 include_recipe "r::install_#{node['r']['install_method']}"
 
+
+# Creating /etc/ folder in installation directory if not existing before (preventing potential directory not found errors)
+# Note: Only directories that did not exist before will be assigned to the given user, in this case: root
+directory node['r']['install_dir'] + '/etc' do
+  owner 'root'
+  group 'root'
+  recursive true
+end
+
 # Setting the default CRAN mirror makes
 # remote administration of R much easier.
 template "#{node['r']['install_dir']}/etc/Rprofile.site" do

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -30,6 +30,10 @@ package "gcc-gfortran"
 include_recipe "build-essential"
 include_recipe "ark"
 
+# installs package (lib)readline(-dev), which is necessary for (output of) R-installation (ie. configure-step)
+#   another option is to install/configure with parameter "--with-readline=no"
+include_recipe 'readline'
+
 ark "R-#{r_version}" do
   url "#{node['r']['cran_mirror']}/src/base/R-#{major_version}/R-#{r_version}.tar.gz"
   autoconf_opts node['r']['config_opts'] if node['r']['config_opts']


### PR DESCRIPTION
> Changed name of global function package_installed?() to r_package_installed?(), as, there are potential overlaps with other cookbooks, eg. function-name overlaps with NodeJS-cookbook provider NPM (which leads to an error when used in combination).
> Installing package (lib)readline(-dev) using readline-cookbook, as, R-installation when invoked without parameter "--with-readline=no" may fail oherwise.
> Preventing (potential) directory not found errors by creating /etc/-folder in installation-directory before using it.