### PR TITLE
Ark does not need explicit configure

### DIFF
--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -36,6 +36,6 @@ include_recipe 'readline'
 ark "R-#{r_version}" do
   url "#{node['r']['cran_mirror']}/src/base/R-#{major_version}/R-#{r_version}.tar.gz"
   autoconf_opts node['r']['config_opts'] if node['r']['config_opts']
-  action [:configure, :install_with_make]
+  action [:install_with_make]
   not_if is_installed_command
 end


### PR DESCRIPTION
Contrary to the docs on ark master, the install_with_make action does indeed run configure. More confusing, if you specify a configure option before install_with_make, the config will take place, but the subsequent make/make install will be skipped (turns out the remote_file test in the install_with_make option causes all of those actions to be skipped after a configure).

This PR changes the action to a simple install_with_make.