### PR TITLE
Linting updates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,38 @@
+AllCops:
+  Include:
+    - '**/Berksfile'
+    - '**/Gemfile'
+    - '**/Rakefile'
+    - '**/Thorfile'
+    - '**/Guardfile'
+  Exclude:
+    - vendor/**
+
+Style/AlignParameters:
+  Exclude:
+    - '**/metadata.rb'
+
+Style/SingleSpaceBeforeFirstArg:
+  Exclude:
+    - '**/metadata.rb'
+
+ClassLength:
+  Enabled: ture
+Documentation:
+  Enabled: true
+Encoding:
+  Enabled: false
+HashSyntax:
+  Enabled: true
+LineLength:
+  Enabled: false
+MethodLength:
+  Exclude:
+    - '**/Rakefile'
+  Enabled: true
+SignalException:
+  Enabled: true
+TrailingComma:
+  Enabled: true
+WordArray:
+  Enabled: true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-default['r']['cran_mirror'] = "http://cran.fhcrc.org/"
+default['r']['cran_mirror'] = 'http://cran.fhcrc.org/'
 
 case node['platform_family']
 when 'debian'
@@ -29,7 +29,7 @@ else
   default['r']['version']        = '3.0.1'
   default['r']['checksum']       = 'af90488af3141103b211dc81b6f17d1f0faf4f17684c579a32dfeb25d0d87134'
   default['r']['install_method'] = 'source'
-  default['r']['config_opts']    = [ "--with-x=no" ]
+  default['r']['config_opts']    = ['--with-x=no']
 end
 
 default['r']['install_dev'] = true

--- a/attributes/install.rb
+++ b/attributes/install.rb
@@ -1,9 +1,8 @@
-include_attribute "r"
-
+include_attribute 'r'
 
 case node['r']['install_method']
-when "package"
-  default['r']['install_dir'] = "/usr/lib/R"
-when "source"
-  default['r']['install_dir'] = node['kernel']['machine'] == 'x86_64' ? "/usr/local/lib64/R" : "/usr/local/lib/R"
+when 'package'
+  default['r']['install_dir'] = '/usr/lib/R'
+when 'source'
+  default['r']['install_dir'] = node['kernel']['machine'] == 'x86_64' ? '/usr/local/lib64/R' : '/usr/local/lib/R'
 end

--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,8 +1,8 @@
 
 def r_package_installed?(package)
-  require "rinruby"
-  R.echo(enable=false)
-  R.eval "packages = installed.packages()[,1]"
-  packages = R.pull "packages"
-  return packages.include?(package)
+  require 'rinruby'
+  R.echo(enable: false)
+  R.eval 'packages = installed.packages()[,1]'
+  packages = R.pull 'packages'
+  packages.include?(package)
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,15 +1,15 @@
-name             "r"
-maintainer       "Steven Danna"
-maintainer_email "steve@opscode.com"
-license          "Apache 2.0"
-description      "Installs/Configures R"
+name             'r'
+maintainer       'Steven Danna'
+maintainer_email 'steve@opscode.com'
+license          'Apache 2.0'
+description      'Installs/Configures R'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.3.0"
+version          '0.3.0'
 
-depends "apt"
-depends "ark"
-depends "build-essential"
+depends 'apt'
+depends 'ark'
+depends 'build-essential'
 depends 'readline'
 
-supports "ubuntu"
-supports "centos"
+supports 'ubuntu'
+supports 'centos'

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -26,27 +26,27 @@ end
 
 action :install do
   if @current_resource.exists
-    Chef::Log.info "#{ @new_resource.name } already exists - nothing to do."
+    Chef::Log.info "#{@new_resource.name} already exists - nothing to do."
   else
-    converge_by("Create #{ @new_resource.name }") do
+    converge_by("Create #{@new_resource.name}") do
       install_package
     end
   end
 end
 
 action :upgrade do
-  converge_by("Create #{ @new_resource.name }") do
+  converge_by("Create #{@new_resource.name}") do
     install_package
   end
 end
 
 action :remove do
   if @current_resource.exists
-    converge_by("Remove #{ @new_resource.name }") do
+    converge_by("Remove #{@new_resource.name}") do
       remove_package
     end
   else
-    Chef::Log.info "#{ @new_resource.name } doesn't exists - nothing to do."
+    Chef::Log.info "#{@new_resource.name} doesn't exists - nothing to do."
   end
 end
 
@@ -54,18 +54,18 @@ def load_current_resource
   @current_resource = Chef::Resource::RPackage.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
   @current_resource.package(@new_resource.package)
-  
-  if r_package_installed?(@current_resource.package)
+
+  only_if r_package_installed?(@current_resource.package) do
     @current_resource.exists = true
   end
 end
 
 def install_package
-  require "rinruby"
+  require 'rinruby'
   R.eval "install.packages('#{new_resource.package}')", false
 end
 
 def remove_package
-  require "rinruby"
+  require 'rinruby'
   R.eval "remove.packages('#{new_resource.package}')", false
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,9 @@
 # limitations under the License.
 #
 
-chef_gem 'rinruby'
+chef_gem 'rinruby' do
+  compile_time false if respond_to?(:compile_time)
+end
 
 include_recipe 'r::repo' if node['r']['install_repo']
 
@@ -36,4 +38,5 @@ end
 template "#{node['r']['install_dir']}/etc/Rprofile.site" do
   mode '0555'
   variables(cran_mirror: node['r']['cran_mirror'])
+  manage_symlink_source true if respond_to?(:manage_symlink_source)
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,11 +19,9 @@
 # limitations under the License.
 #
 
-chef_gem "rinruby"
+chef_gem 'rinruby'
 
-if node['r']['install_repo']
-  include_recipe "r::repo"
-end
+include_recipe 'r::repo' if node['r']['install_repo']
 
 include_recipe "r::install_#{node['r']['install_method']}"
 
@@ -36,6 +34,6 @@ end
 # Setting the default CRAN mirror makes
 # remote administration of R much easier.
 template "#{node['r']['install_dir']}/etc/Rprofile.site" do
-  mode "0555"
-  variables( :cran_mirror => node['r']['cran_mirror'])
+  mode '0555'
+  variables(cran_mirror: node['r']['cran_mirror'])
 end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -27,5 +27,5 @@ end
 package 'r-base-dev' do
   version node['r']['version'] if node['r']['version']
   action :install
-  only_if node['r']['install_dev']
+  only_if { node['r']['install_dev'] == true }
 end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -24,8 +24,9 @@ package 'r-base' do
   action :install
 end
 
-package 'r-base-dev' do
-  version node['r']['version'] if node['r']['version']
-  action :install
-  only_if { node['r']['install_dev'] == true }
+if node['r']['install_dev'] # ~FC023
+  package 'r-base-dev' do
+    version node['r']['version'] if node['r']['version']
+    action :install
+  end
 end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -24,9 +24,8 @@ package 'r-base' do
   action :install
 end
 
-if node['r']['install_dev']
-  package 'r-base-dev' do
-    version node['r']['version'] if node['r']['version']
-    action :install
-  end
+package 'r-base-dev' do
+  version node['r']['version'] if node['r']['version']
+  action :install
+  only_if node['r']['install_dev']
 end

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -20,15 +20,15 @@
 #
 
 r_version = node['r']['version']
-major_version = r_version.split(".").first
+major_version = r_version.split('.').first
 
 # Command to check if we should be installing R or not.
 is_installed_command = "R --version | grep -q #{r_version}"
 
-package "gcc-gfortran"
+package 'gcc-gfortran'
 
-include_recipe "build-essential"
-include_recipe "ark"
+include_recipe 'build-essential'
+include_recipe 'ark'
 
 # required unless "--with-readline=no" is used
 include_recipe 'readline'

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -21,28 +21,28 @@
 #
 
 case node['platform_family']
-when "debian"
-  include_recipe "apt"
+when 'debian'
+  include_recipe 'apt'
 
   case node['platform']
-  when "debian"
-    postfix = if node['r']['version'] && node['r']['version'].split(".").first == "2"
-                ""
+  when 'debian'
+    postfix = if node['r']['version'] && node['r']['version'].split('.').first == '2'
+                ''
               else
-                "3"
+                '3'
               end
     distro_name = "#{node['lsb']['codename']}-cran#{postfix}"
-    keyserver_url = "pgp.mit.edu"
-    key_id = "381BA480"
-  when "ubuntu"
+    keyserver_url = 'pgp.mit.edu'
+    key_id = '381BA480'
+  when 'ubuntu'
     distro_name = node['lsb']['codename']
-    keyserver_url = "keyserver.ubuntu.com"
-    key_id = "E084DAB9"
+    keyserver_url = 'keyserver.ubuntu.com'
+    key_id = 'E084DAB9'
   else
-    return "platform not supported"
+    return 'platform not supported'
   end
 
-  apt_repository "cran-apt-repo" do
+  apt_repository 'cran-apt-repo' do
     uri "#{node['r']['cran_mirror']}/bin/linux/#{node['platform']}"
     distribution "#{distro_name}/"
     components []

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -22,7 +22,7 @@
 actions :install, :remove, :upgrade
 default_action :install
 
-attribute :package, :kind_of => String, :name_attribute => true
+attribute :package, { kind_of: String }, name_attribute: true
 
 attr_accessor :exists
 

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -22,7 +22,7 @@
 actions :install, :remove, :upgrade
 default_action :install
 
-attribute :package, { kind_of: String }, name_attribute: true
+attribute :package, kind_of: String, name_attribute: true
 
 attr_accessor :exists
 


### PR DESCRIPTION
A series of rather pedantic updates to correct `foodcritic` and `rubocop` lint warnings. Also corrects chef run warnings around `compile_time` and `manage_symlink_source` options (with guards for downlevel Chef support).

Verified with full kitchen converge (separate PR on kitchen to follow) :smile: