### PR TITLE
Add support for AWS Linux and Debian

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,17 +7,16 @@ provisioner:
   name: chef_zero
 
 platforms:
+- name: ubuntu-16.04
 - name: ubuntu-14.04
 - name: ubuntu-12.04
-- name: ubuntu-10.04
-  driver_config:
-    box: opscode-ubuntu-14.04
 - name: centos-6.7
-  driver_config:
-    box: opscode-centos-6.7
 - name: centos-5.11
 - name: debian-8.2
 suites:
 - name: default
   run_list: ["recipe[r]"]
-  attributes: {}
+  attributes:
+    chef_client:
+      config:
+        log_level: ":debug"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,27 +3,20 @@ driver_plugin: vagrant
 driver_config:
   require_chef_omnibus: true
 
+provisioner:
+  name: chef_zero
+
 platforms:
+- name: ubuntu-14.04
 - name: ubuntu-12.04
-  driver_config:
-    box: opscode-ubuntu-12.04
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
 - name: ubuntu-10.04
   driver_config:
     box: opscode-ubuntu-10.04
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
 - name: centos-6.4
   driver_config:
-    box: opscode-centos-6.4
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-6.4_provisionerless.box
-- name: centos-5.9
-  driver_config:
-    box: opscode-centos-5.9
-    box_url: https://opscode-vm.s3.amazonaws.com/vagrant/opscode_centos-5.9_provisionerless.box
-- name: debian-7
-  driver_config:
-    box: opscode-debian-7.1
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_debian-7.1.0_provisionerless.box
+    box: opscode-centos-6.7
+- name: centos-5.11
+- name: debian-8.2
 suites:
 - name: default
   run_list: ["recipe[r]"]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,8 +11,8 @@ platforms:
 - name: ubuntu-12.04
 - name: ubuntu-10.04
   driver_config:
-    box: opscode-ubuntu-10.04
-- name: centos-6.4
+    box: opscode-ubuntu-14.04
+- name: centos-6.7
   driver_config:
     box: opscode-centos-6.7
 - name: centos-5.11

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ Style/AlignParameters:
   Exclude:
     - '**/metadata.rb'
 
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Exclude:
     - '**/metadata.rb'
 
@@ -32,7 +32,9 @@ MethodLength:
   Enabled: true
 SignalException:
   Enabled: true
-TrailingComma:
+TrailingCommaInLiteral:
+  Enabled: true
+TrailingCommaInArguments:
   Enabled: true
 WordArray:
   Enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 rvm:
-  - 2.2
+  - 2.3
 before_install:
   - gem update --system
   - gem --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 rvm:
-  - 2.0.0
+  - 2.2
 script:
   - bundle exec foodcritic -f any .
   - bundle exec rspec --color --format progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 rvm:
   - 2.2
+before_install:
+  - gem update --system
+  - gem --version
 script:
   - bundle exec foodcritic -f any .
   - bundle exec rspec --color --format progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 rvm:
-  - 2.3
+  - 2.3.1
 before_install:
   - gem update --system
   - gem --version

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,4 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 metadata
+cookbook 'yum-epel', '~> 2.0.0', :supermarket

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@
 default['r']['cran_mirror'] = 'http://cran.fhcrc.org/'
 
 case node['platform_family']
-when 'debian'
+when 'debian', 'rhel'
   default['r']['install_method'] = 'package'
   default['r']['install_repo']   = true
 else
@@ -32,4 +32,9 @@ else
   default['r']['config_opts']    = ['--with-x=no']
 end
 
-default['r']['install_dev'] = true
+case node['platform_family']
+when 'rhel'
+  default['r']['install_dev'] = false
+else
+  default['r']['install_dev'] = true
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,9 +32,9 @@ else
   default['r']['config_opts']    = ['--with-x=no']
 end
 
-case node['platform_family']
-when 'rhel'
-  default['r']['install_dev'] = false
-else
-  default['r']['install_dev'] = true
-end
+default['r']['install_dev'] = case node['platform_family']
+                              when 'rhel'
+                                false
+                              else
+                                true
+                              end

--- a/chefignore
+++ b/chefignore
@@ -94,3 +94,7 @@ Vagrantfile
 # Travis #
 ##########
 .travis.yml
+
+# Test-Kitchen #
+################
+.kitchen

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,6 +10,7 @@ depends 'apt'
 depends 'ark'
 depends 'build-essential'
 depends 'readline'
+depends 'yum-epel', '>=2.0.0'
 
 supports 'ubuntu'
 supports 'centos'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,3 +13,5 @@ depends 'readline'
 
 supports 'ubuntu'
 supports 'centos'
+supports 'amazon'
+supports 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,6 @@
 # limitations under the License.
 #
 
-
 chef_gem 'rinruby' do # ~FC009
   compile_time false if respond_to?(:compile_time)
 end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -19,7 +19,16 @@
 # limitations under the License.
 #
 
-package 'r-base' do
+pkg_name = case node['platform_family']
+           when 'rhel'
+             'R'
+           when 'debian'
+             'r-base'
+           else
+             'r_base'
+end
+
+package pkg_name do
   version node['r']['version'] if node['r']['version']
   action :install
 end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -26,7 +26,7 @@ pkg_name = case node['platform_family']
              'r-base'
            else
              'r_base'
-end
+           end
 
 package pkg_name do
   version node['r']['version'] if node['r']['version']

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -28,6 +28,8 @@ pkg_name = case node['platform_family']
              'r_base'
            end
 
+include_recipe 'yum-epel::default' if node['platform_family'] == 'rhel'
+
 package pkg_name do
   version node['r']['version'] if node['r']['version']
   action :install


### PR DESCRIPTION
Support the AWS Linux and Debian platforms. Centos not yet supported (requires EPEL).
