### PR TITLE
Fixing issue on r_package when checking if the package exists already…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin/*
 
 .kitchen/
 .kitchen.local.yml
+
+*.iml

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -55,9 +55,7 @@ def load_current_resource
   @current_resource.name(@new_resource.name)
   @current_resource.package(@new_resource.package)
 
-  only_if r_package_installed?(@current_resource.package) do
-    @current_resource.exists = true
-  end
+  @current_resource.exists = r_package_installed?(@current_resource.package)
 end
 
 def install_package


### PR DESCRIPTION
This fixes the run on Chef 12.4.3. Now, ideally we should cache the result of the check somehow. Maybe a file. And add an entry to that file if an R package is installed with r_package.

The output is kind of annoying too. But, it works.