### PR TITLE
adds rhel package manager support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,14 +22,16 @@
 default['r']['cran_mirror'] = "http://cran.fhcrc.org/"
 
 case node['platform_family']
-when 'debian'
-  default['r']['install_method'] = 'package'
-  default['r']['install_repo']   = true
-else
-  default['r']['version']        = '3.0.1'
-  default['r']['checksum']       = 'af90488af3141103b211dc81b6f17d1f0faf4f17684c579a32dfeb25d0d87134'
-  default['r']['install_method'] = 'source'
-  default['r']['config_opts']    = [ "--with-x=no" ]
+  when 'rhel'
+    default['r']['install_method'] = 'package'
+  when 'debian'
+    default['r']['install_method'] = 'package'
+    default['r']['install_repo']   = true
+  else
+    default['r']['version']        = '3.0.1'
+    default['r']['checksum']       = 'af90488af3141103b211dc81b6f17d1f0faf4f17684c579a32dfeb25d0d87134'
+    default['r']['install_method'] = 'source'
+    default['r']['config_opts']    = [ "--with-x=no" ]
 end
 
 default['r']['install_dev'] = true

--- a/attributes/install.rb
+++ b/attributes/install.rb
@@ -1,9 +1,7 @@
 include_attribute "r"
 
-
-case node['r']['install_method']
-when "package"
+if node['r']['install_method'] == 'package' and node['platform_family'] == 'debian'
   default['r']['install_dir'] = "/usr/lib/R"
-when "source"
+else
   default['r']['install_dir'] = node['kernel']['machine'] == 'x86_64' ? "/usr/local/lib64/R" : "/usr/local/lib/R"
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name             "r"
-maintainer       "Steven Danna"
-maintainer_email "steve@opscode.com"
+maintainer       "NativeX"
+maintainer_email "adrian.herrera@nativex.com"
 license          "Apache 2.0"
 description      "Installs/Configures R"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
@@ -9,6 +9,7 @@ version          "0.3.0"
 depends "apt"
 depends "ark"
 depends "build-essential"
+depends "java"
 
 supports "ubuntu"
 supports "centos"

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -1,10 +1,10 @@
 #
 # Author:: Steven Danna(<steve@opscode.com>)
 # Cookbook Name:: R
-# Recipe:: default
+# Recipe:: package
 #
 # Copyright 2011-2013, Steven S. Danna (<steve@opscode.com>)
-# Copyright 2013, Mark Van de Vyver (<mark@taqtiqa.com>)
+# Copyright 2013, Mark Van de Vyver (<mark@taqtiqa.com>)#
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,7 @@
 #
 
 chef_gem "rinruby"
+require 'fileutils'
 
 if node['r']['install_repo']
   include_recipe "r::repo"
@@ -32,4 +33,9 @@ include_recipe "r::install_#{node['r']['install_method']}"
 template "#{node['r']['install_dir']}/etc/Rprofile.site" do
   mode "0555"
   variables( :cran_mirror => node['r']['cran_mirror'])
+end
+
+dirname = "/usr/local/lib64/R/etc"
+unless File.directory?(dirname)
+  FileUtils.mkdir_p(dirname)
 end

--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Steven Danna(<steve@opscode.com>)
 # Cookbook Name:: R
-# Recipe:: package
+# Recipe:: install_package
 #
 # Copyright 2011-2013, Steven S. Danna (<steve@opscode.com>)
 # Copyright 2013, Mark Van de Vyver (<mark@taqtiqa.com>)
@@ -19,14 +19,29 @@
 # limitations under the License.
 #
 
-package 'r-base' do
-  version node['r']['version'] if node['r']['version']
-  action :install
-end
-
-if node['r']['install_dev']
-  package 'r-base-dev' do
+case node['platform_family']
+when 'debian'
+  package 'r-base' do
     version node['r']['version'] if node['r']['version']
     action :install
+  end
+
+  if node['r']['install_dev']
+    package 'r-base-dev' do
+      version node['r']['version'] if node['r']['version']
+      action :install
+    end
+  end
+when 'rhel'
+  if node['r']['install_dev']
+    package 'R-devel' do
+      version node['r']['version'] if node['r']['version']
+      action :install
+    end
+  else
+    package 'R' do
+      version node['r']['version'] if node['r']['version']
+      action :install
+    end
   end
 end

--- a/recipes/install_source.rb
+++ b/recipes/install_source.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Steven Danna(<steve@opscode.com>)
 # Cookbook Name:: R
-# Recipe:: default
+# Recipe:: install_source
 #
 # Copyright 2011-2013, Steven S. Danna (<steve@opscode.com>)
 # Copyright 2013, Mark Van de Vyver (<mark@taqtiqa.com>)
@@ -33,6 +33,14 @@ include_recipe "ark"
 ark "R-#{r_version}" do
   url "#{node['r']['cran_mirror']}/src/base/R-#{major_version}/R-#{r_version}.tar.gz"
   autoconf_opts node['r']['config_opts'] if node['r']['config_opts']
-  action [:configure, :install_with_make]
+  action [:configure]
+  not_if is_installed_command
+end
+
+bash "build-and-install-r" do
+  user "root"
+  code <<-EOH
+  (cd /usr/local/R-#{r_version}-1/ && make && make install)
+  EOH
   not_if is_installed_command
 end

--- a/recipes/repo.rb
+++ b/recipes/repo.rb
@@ -1,6 +1,5 @@
 #
 # Author:: Steven Danna(<steve@opscode.com>)
-# Author:: Guilhem Lettron <guilhem.lettron@youscribe.com
 # Cookbook Name:: R
 # Recipe:: repo
 #

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -1,10 +1,8 @@
 #
-# Author:: Steven Danna (<steve@opscode.com>)
+# Author:: Adrian Herrera (<adrian.herrera@nativex.com>)
 # Cookbook Name:: R
 # Provider:: package
 #
-# Copyright 2011-2013, Steven S. Danna (<steve@opscode.com>)
-# Copyright 2013, Mark Van de Vyver (<mark@taqtiqa.com>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/package.rb
+++ b/resources/package.rb
@@ -1,8 +1,10 @@
 #
-# Author:: Adrian Herrera (<adrian.herrera@nativex.com>)
+# Author:: Steven Danna (<steve@opscode.com>)
 # Cookbook Name:: R
 # Provider:: package
 #
+# Copyright 2011-2013, Steven S. Danna (<steve@opscode.com>)
+# # Copyright 2013, Mark Van de Vyver (<mark@taqtiqa.com>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
don't expect this pull request to get merged in, but may help with coding rpm support for rhel based distros. Epel repo is needed for R rpm packages so will probably have to add dependancy on yum-epel cookbook if platform family is rhel. Feel free to use any parts of this code as needed. Fix for #31 
